### PR TITLE
Read from a file-like object

### DIFF
--- a/tests/test_guano.py
+++ b/tests/test_guano.py
@@ -36,6 +36,24 @@ class UnicodeTest(unittest.TestCase):
 
         self.assertEqual(self.NOTE, g2['Note'])
 
+    def test_filelike_roundtrip(self):
+        """Same as test_file_roundtrip, but reading a file-like object, not filename."""
+        fname = 'test_guano.wav'
+
+        # write a fake .WAV file
+        g = GuanoFile.from_string(self.MD)
+        g.filename = fname
+        g.wav_params = wavparams(1, 2, 500000, 2, 'NONE', None)
+        g._wav_data = b'\01\02'  # faking it, don't try this at home!
+        g._wav_data_size = 2
+        g.write()
+
+        # read it back in
+        with open(fname, 'rb') as f:
+            g2 = GuanoFile(f)
+
+        self.assertEqual(self.NOTE, g2['Note'])
+
 
 class GeneralTest(unittest.TestCase):
 


### PR DESCRIPTION
This PR extends `GuanoPy` to allow reading from any file-like object (one that implements methods seek, read, tell), not just via filename.

This is important when the very large WAV file exists over a network and we want to extract GUANO  metadata without downloading the entire sound data.


## What I changed

* `GuanoPy.__init__` arg switched from `filename` to `file`:
     - If `file` is a string, opens the file by that name,
    - otherwise if `file` is set, treat it as a file-like object  (one that implements methods seek, read, tell).

* Add `filename` property that returns a string only if this GuanoPy object references a file by its filename. This is settable if you want to write a "new" file.

* Places that GuanoPy actually has to open the file (`_load` and `write` methods), check if the `self.filename` property is set (i.e. we have a string); if so, open it as usual, otherwise simply return the file-like object from a [`contextlib.nullcontext()`](https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext)

* New test case to read a from file-like object: an already open file handle.